### PR TITLE
feat: Web Worker를 사용한 타이머 개선

### DIFF
--- a/Stargate-Fe/public/timerWorker.ts
+++ b/Stargate-Fe/public/timerWorker.ts
@@ -1,0 +1,3 @@
+setInterval(() => {
+  postMessage('1000ms');
+}, 1000);

--- a/Stargate-Fe/src/hooks/useFetchBoardData.ts
+++ b/Stargate-Fe/src/hooks/useFetchBoardData.ts
@@ -1,15 +1,18 @@
 import { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { browserState } from '@/recoil/browserState';
 import { BoardData } from '@/types/board/type';
 import { fetchUserBoard } from '@/services/userBoardService';
 import { fetchAdminBoard } from '@/services/adminBoardService';
 
-export const useFetchData = (isAdmin: boolean) => {
+export const useFetchBoardData = (isAdmin: boolean) => {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BoardData>({
     ongoing: [],
     expected: [],
     finished: [],
   });
+  const isV8 = useRecoilValue(browserState);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -22,18 +25,23 @@ export const useFetchData = (isAdmin: boolean) => {
       setLoading(false);
     };
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        fetchData();
-      }
-    };
-    fetchData();
+    if (!isV8) {
+      const handleVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+          fetchData();
+        }
+      };
+      fetchData();
 
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, []);
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+      return () => {
+        document.removeEventListener(
+          'visibilitychange',
+          handleVisibilityChange
+        );
+      };
+    }
+  }, [isV8]);
 
   return { loading, data, setData };
 };

--- a/Stargate-Fe/src/hooks/useUpdateTime.ts
+++ b/Stargate-Fe/src/hooks/useUpdateTime.ts
@@ -12,7 +12,7 @@ export const useUpdateTime = (
   const isV8 = useRecoilValue(browserState);
 
   useEffect(() => {
-    if (isV8) {
+    if (isV8 && window.Worker) {
       const worker = new Worker('./timerWorker.ts');
 
       worker.onmessage = () => {

--- a/Stargate-Fe/src/pages/admin/board/AdminBoard.tsx
+++ b/Stargate-Fe/src/pages/admin/board/AdminBoard.tsx
@@ -1,10 +1,10 @@
 import BoardTemplate from '@/template/board/BoardTemplate';
-import { useFetchData } from '@/hooks/useFetchBoardData';
+import { useFetchBoardData } from '@/hooks/useFetchBoardData';
 import { useUpdateTime } from '@/hooks/useUpdateTime';
 import { MeetingBoardData } from '@/types/board/type';
 
 const AdminBoard = () => {
-  const { loading, data, setData } = useFetchData(true);
+  const { loading, data, setData } = useFetchBoardData(true);
   useUpdateTime(data, setData);
 
   /**

--- a/Stargate-Fe/src/pages/auth/SignIn.tsx
+++ b/Stargate-Fe/src/pages/auth/SignIn.tsx
@@ -1,23 +1,19 @@
 import React, { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { browserState } from '@/recoil/browserState';
 import SignInComponent from '@/organisms/auth/SignInComponent';
 import ToolTipComponent from '@/atoms/auth/ToolTipComponent';
-import Swal from 'sweetalert2';
+import { browserAlert } from '@/utils/browserAlert';
 
 const SignIn = () => {
+  const setBrowser = useSetRecoilState(browserState);
+  const userAgent = window.navigator.userAgent;
+
   useEffect(() => {
-    const userAgent = window.navigator.userAgent;
-    if (userAgent.includes('Mac')) {
-      Swal.fire({
-        icon: 'warning',
-        title: '운영체제 권장 안내',
-        text: '최적의 실행환경을 위해 Windows 운영체제를 권장합니다.',
-      });
-    } else if (userAgent.includes('Firefox')) {
-      Swal.fire({
-        icon: 'warning',
-        title: '브라우저 권장 안내',
-        text: '최적의 사용을 위해 Chrome 혹은 Edge 브라우저를 권장합니다.',
-      });
+    console.log(userAgent);
+    if (userAgent.includes('Mac') || userAgent.includes('Firefox')) {
+      setBrowser(false);
+      browserAlert(userAgent);
     }
   }, []);
 

--- a/Stargate-Fe/src/pages/user/board/UserBoard.tsx
+++ b/Stargate-Fe/src/pages/user/board/UserBoard.tsx
@@ -1,10 +1,10 @@
 import BoardTemplate from '@/template/board/BoardTemplate';
-import { useFetchData } from '@/hooks/useFetchBoardData';
+import { useFetchBoardData } from '@/hooks/useFetchBoardData';
 import { useUpdateTime } from '@/hooks/useUpdateTime';
 import { MeetingBoardData } from '@/types/board/type';
 
 const UserBoard = () => {
-  const { loading, data, setData } = useFetchData(false);
+  const { loading, data, setData } = useFetchBoardData(false);
   useUpdateTime(data, setData);
 
   /**

--- a/Stargate-Fe/src/recoil/browserState.ts
+++ b/Stargate-Fe/src/recoil/browserState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const browserState = atom<boolean>({
+  key: 'browserState',
+  default: true,
+});

--- a/Stargate-Fe/src/template/board/BoardTemplate.tsx
+++ b/Stargate-Fe/src/template/board/BoardTemplate.tsx
@@ -1,9 +1,13 @@
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { browserState } from '@/recoil/browserState';
 import PlusButton from '@/atoms/board/PlusMinusButton';
 import BoardCardBox from '@/organisms/board/BoardCardBox';
 import BoardCardList from '@/organisms/board/BoardCardList';
 import BoardHeader from '@/organisms/board/BoardHeader';
 import { BoardData, MeetingBoardData } from '@/types/board/type';
 import { Link } from 'react-router-dom';
+import { browserAlert } from '@/utils/browserAlert';
 
 interface BoardTemplateProps {
   isAdmin: boolean;
@@ -24,6 +28,16 @@ const BoardTemplate = ({
   isExpected,
   isFinished,
 }: BoardTemplateProps) => {
+  const setBrowser = useSetRecoilState(browserState);
+  const userAgent = window.navigator.userAgent;
+
+  useEffect(() => {
+    if (userAgent.includes('Mac') || userAgent.includes('Firefox')) {
+      setBrowser(false);
+      browserAlert(userAgent);
+    }
+  }, []);
+
   return (
     <div className="flex flex-col justify-around min-h-screen bg-no-repeat bg-cover w-xl bg-gradient-to-b from-mainblue to-mainyellow">
       <BoardHeader isAdmin={isAdmin} />

--- a/Stargate-Fe/src/utils/browserAlert.ts
+++ b/Stargate-Fe/src/utils/browserAlert.ts
@@ -1,0 +1,17 @@
+import Swal from 'sweetalert2';
+
+export const browserAlert = (userAgent: string) => {
+  if (userAgent.includes('Mac')) {
+    Swal.fire({
+      icon: 'warning',
+      title: '운영체제 권장 안내',
+      text: '최적의 실행환경을 위해 Windows 운영체제를 권장합니다.',
+    });
+  } else if (userAgent.includes('Firefox')) {
+    Swal.fire({
+      icon: 'warning',
+      title: '브라우저 권장 안내',
+      text: '최적의 사용을 위해 Chrome 혹은 Edge 브라우저를 권장합니다.',
+    });
+  }
+};


### PR DESCRIPTION
### Part
  - [x] FE
  - [ ] BE
<br>

### Changes
- 기존 Page Visibility API를 사용하는 방식은 페이지가 재활성화 될 때마다 데이터를 새로 가져오는 방식이였습니다.
- 이는 서버 리소스를 소모하고, 데이터가 리랜더링 되는 과정에서 유저에게 노출되기에 UX측면에서 단점이 있었습니다.
- 이를 개선하고자 Web Worker를 사용해 Timer를 동작시키도록 수정하였습니다.
- 자세한 사항은 https://cksxkr5193.tistory.com/50 를 참조해주시기 바랍니다.
- SignIn 페이지 외에도 Board 템플릿에 OS/브라우저 체크를 넣었습니다.
- OS/브라우저 상태값을 recoil에 저장해서 경고문 출력과 타이머 동작 여부 분기 처리에 사용하도록 했습니다. 
<br>

### Test Checklist ☑️
- [x] 타이머가 정상적으로 작동하는지
- [x] 크로스 브라우징을 고려해 구현하였는지

### Screenshot(option)

<br>
